### PR TITLE
adjusted support for units of inches in accuracy

### DIFF
--- a/map.controller.js
+++ b/map.controller.js
@@ -72,10 +72,16 @@
                                     icon: icon
                                 };
 
-                                if (accuracyItem && accuracyItem.type === 'Number' && parseFloat(accuracyItem.state) > 0) {
+                                if (accuracyItem && accuracyItem.type.includes('Number') && parseFloat(accuracyItem.state) > 0) {
+                                    var value = parseFloat(accuracyItem.state);
+                                    // Convert inches to meters if 'in' is present in the accuracy (supports GPSLogger).
+                                    if (accuracyItem.state.includes('in')) {
+                                        value /= 39.3701;
+                                    }
+
                                     vm.paths[item.name] = {
                                         type: 'circle',
-                                        radius: parseFloat(accuracyItem.state),
+                                        radius: value,
                                         latlngs: vm.markers[item.name],
                                         color: icon.markerColor,
                                         weight: 2


### PR DESCRIPTION
Love the widget.  While playing with my setup using the GPSlogger binding I noticed that the "accuracy" was in inches rather than meters as your widget expected.  I added support to the JavaScript to handle conversion from inches to meters when OpenHAB appends the units "in" to the accuracy state.

Thought that it might be useful to the next guy too.